### PR TITLE
Separate collection link generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.7.0
+
 - ✨ Add `extract_set_links` to serializer for collection links
 
 ## 0.7.0.beta1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.0
+- ✨ Add `extract_set_links` to serializer for collection links
+
 ## 0.7.0.beta1
 
 - 🐛 Fix non-serializer media types replacing known serializers

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ class Book < ApplicationRecord
       { href: context.api_book_url(serializable) }
     end
 
-    def extract_links(view:)
+    def extract_links
       { 
         'self': extract_self,
         'signatures': { href: context.api_book_signatures_url(serializable) }

--- a/lib/generators/media_types/serialization/api_viewer/templates/initializer.rb
+++ b/lib/generators/media_types/serialization/api_viewer/templates/initializer.rb
@@ -14,8 +14,8 @@ require 'media_types/serialization/media_type/register'
 # to define +_links+ for the root level from your serializer.
 #
 #
-# MediaTypes::Serialization.collect_links_for_collection = true
-# MediaTypes::Serialization.collect_links_for_index = true
+MediaTypes::Serialization.collect_links_for_collection = true
+MediaTypes::Serialization.collect_links_for_index = true
 
 ##
 # The API Viewer template is provided if you used the generator. You can change

--- a/lib/media_types/serialization/base.rb
+++ b/lib/media_types/serialization/base.rb
@@ -65,7 +65,7 @@ module MediaTypes
       end
 
       def header_links(view: current_view)
-        extract_links(view: view)
+        extract_view_links(view: view)
       end
 
       def set(serializable)
@@ -78,8 +78,19 @@ module MediaTypes
       attr_accessor :context
       attr_writer :current_media_type, :current_view, :serializable
 
-      def extract_links(view: current_view)
+      def extract_links
         {}
+      end
+
+      def extract_set_links(view: current_view)
+        {}
+      end
+
+      def extract_view_links(view: current_view)
+        return extract_set_links(view: view) if view == ::MediaTypes::INDEX_VIEW
+        return extract_set_links(view: view) if view == ::MediaTypes::COLLECTION_VIEW
+
+        extract_links
       end
 
       def extract(extractable, *keys)

--- a/lib/media_types/serialization/wrapper/media_collection_wrapper.rb
+++ b/lib/media_types/serialization/wrapper/media_collection_wrapper.rb
@@ -34,7 +34,7 @@ module MediaTypes
         protected
 
         def extract_links(view: current_view)
-          return __getobj__.send(:extract_links, view: view) if ::MediaTypes::Serialization.collect_links_for_collection
+          return __getobj__.send(:extract_set_links, view: view) if ::MediaTypes::Serialization.collect_links_for_collection
           {}
         end
 

--- a/lib/media_types/serialization/wrapper/media_index_wrapper.rb
+++ b/lib/media_types/serialization/wrapper/media_index_wrapper.rb
@@ -46,7 +46,7 @@ module MediaTypes
         end
 
         def extract_links(view: current_view)
-          return __getobj__.send(:extract_links, view: view) if ::MediaTypes::Serialization.collect_links_for_index
+          return __getobj__.send(:extract_set_links, view: view) if ::MediaTypes::Serialization.collect_links_for_index
           {}
         end
 

--- a/lib/media_types/serialization/wrapper/media_object_wrapper.rb
+++ b/lib/media_types/serialization/wrapper/media_object_wrapper.rb
@@ -43,7 +43,7 @@ module MediaTypes
         end
 
         def extract_links(view: current_view)
-          __getobj__.send(:extract_links, view: view)
+          __getobj__.send(:extract_set_links, view: view)
         end
 
         def root_key(view: current_view)

--- a/test/media_types/collection_wrapper_test.rb
+++ b/test/media_types/collection_wrapper_test.rb
@@ -59,9 +59,11 @@ class MediaTypes::CollectionWrapperTest < Minitest::Test
       { href: '/item' }
     end
 
-    def extract_links(view: current_view)
-      return { href: '/path/to/collection' } if view == ::MediaTypes::COLLECTION_VIEW
+    def extract_set_links(view: current_view)
+      { href: '/path/to/collection' }
+    end
 
+    def extract_links
       {
         self: extract_self(view: view),
         google: { href: 'https://google.com', foo: 'bar' }

--- a/test/media_types/index_wrapper_test.rb
+++ b/test/media_types/index_wrapper_test.rb
@@ -59,9 +59,11 @@ class MediaTypes::IndexWrapperTest < Minitest::Test
       { href: '/item' }
     end
 
-    def extract_links(view: current_view)
-      return { href: '/path/to/index' } if view == ::MediaTypes::INDEX_VIEW
+    def extract_set_links(view: current_view)
+      { href: '/path/to/index' }
+    end
 
+    def extract_links
       {
         self: extract_self(view: view),
         google: { href: 'https://google.com', foo: 'bar' }

--- a/test/media_types/object_wrapper_test.rb
+++ b/test/media_types/object_wrapper_test.rb
@@ -58,7 +58,7 @@ class MediaTypes::ObjectWrapperTest < Minitest::Test
       { href: '/item' }
     end
 
-    def extract_links(*)
+    def extract_view_links(*)
       {
         self: extract_self,
         google: { href: 'https://google.com', foo: 'bar' }

--- a/test/media_types/root_key_test.rb
+++ b/test/media_types/root_key_test.rb
@@ -59,7 +59,7 @@ class MediaTypes::RootKeyTest < Minitest::Test
       { href: '/item' }
     end
 
-    def extract_links(view: current_view)
+    def extract_view_links(view: current_view)
       {
         self: extract_self(view: view),
         google: { href: 'https://google.com', foo: 'bar' }

--- a/test/media_types/serialization_test.rb
+++ b/test/media_types/serialization_test.rb
@@ -65,7 +65,7 @@ class MediaTypes::SerializationTest < Minitest::Test
       to_hash.merge(source: 'to_json').to_json(options)
     end
 
-    def extract_links(*)
+    def extract_view_links(*)
       { google: { href: 'https://google.com', foo: 'bar' } }
     end
   end


### PR DESCRIPTION
Adds extract_set_links to generate the links for collections instead of overloading the extract_links function.