### PR TITLE
Fixes input_alias registration

### DIFF
--- a/lib/media_types/serialization/base.rb
+++ b/lib/media_types/serialization/base.rb
@@ -102,18 +102,18 @@ module MediaTypes
           end
         end
 
-        def input_alias(media_type_identifier, view: nil, hide_variant: false)
+        def input_alias(media_type_identifier, view: nil)
           validator = serializer_validator.view(view)
           victim_identifier = validator.identifier
 
-          serializer_input_registration.register_alias(self, media_type_identifier, victim_identifier, false, hide_variant, wildcards: !self.serializer_disable_wildcards)
+          serializer_input_registration.register_alias(self, media_type_identifier, victim_identifier, false, true, wildcards: false)
         end
 
-        def input_alias_optional(media_type_identifier, view: nil, hide_variant: false)
+        def input_alias_optional(media_type_identifier, view: nil)
           validator = serializer_validator.view(view)
           victim_identifier = validator.identifier
 
-          serializer_input_registration.register_alias(self, media_type_identifier, victim_identifier, true, hide_variant, wildcards: !self.serializer_disable_wildcards)
+          serializer_input_registration.register_alias(self, media_type_identifier, victim_identifier, true, true, wildcards: false)
         end
 
         def serialize(victim, media_type_identifier, context, dsl: nil, raw: nil)

--- a/lib/media_types/serialization/base.rb
+++ b/lib/media_types/serialization/base.rb
@@ -102,18 +102,18 @@ module MediaTypes
           end
         end
 
-        def input_alias(media_type_identifier, view: nil)
+        def input_alias(media_type_identifier, view: nil, hide_variant: false)
           validator = serializer_validator.view(view)
           victim_identifier = validator.identifier
 
-          serializer_input_registration.register_alias(self, media_type_identifier, victim_identifier, false)
+          serializer_input_registration.register_alias(self, media_type_identifier, victim_identifier, false, hide_variant, wildcards: !self.serializer_disable_wildcards)
         end
 
-        def input_alias_optional(media_type_identifier, view: nil)
+        def input_alias_optional(media_type_identifier, view: nil, hide_variant: false)
           validator = serializer_validator.view(view)
           victim_identifier = validator.identifier
 
-          serializer_input_registration.register_alias(self, media_type_identifier, victim_identifier, true)
+          serializer_input_registration.register_alias(self, media_type_identifier, victim_identifier, true, hide_variant, wildcards: !self.serializer_disable_wildcards)
         end
 
         def serialize(victim, media_type_identifier, context, dsl: nil, raw: nil)


### PR DESCRIPTION
Fixes a missing parameter.

Without this fix, `input_alias` always breaks because the internal call to `register_alias` _requires_ at least 5 parameters.