### PR TITLE
Pass victim to HTML as locals / assigns to normalize usage

### DIFF
--- a/lib/media_types/serialization.rb
+++ b/lib/media_types/serialization.rb
@@ -195,12 +195,14 @@ module MediaTypes
 
           validator = FakeValidator.new(as.nil? ? 'text/html' : as)
 
-          block = lambda { |_, _, controller|
+          block = lambda { |victim, _, controller|
             options = {}
             options[:layout] = layout unless layout.nil?
             options[:template] = view unless view.nil?
             options[:formats] = formats unless formats.nil?
             options[:variants] = variants unless variants.nil?
+            options[:locals] = victim if victim.is_a?(Hash)
+            options[:assigns] = { media: victim }
 
             controller.render_to_string(**options)
           }


### PR DESCRIPTION
This also allows us to keep the same views if we upgrade to HTML via render_media.

```ruby
render_media(foo: 42, bar: 100)

#==== inside representation ====
[...] |obj, version, context|
# obj[:foo] => 42

#==== inside html ====
# local_assigns[:foo] => 42
# @media => { foo: 42, bar: 100 }
```